### PR TITLE
Make `QGate` expect a `wire_list` rather than a `wire`.

### DIFF
--- a/quippy/quipper.g
+++ b/quippy/quipper.g
@@ -58,7 +58,7 @@ NO_CONTROL : "with nocontrol"
 // Gate definitions
 // Note: ] and ( have to be separate tokens for the lexer.
 !inversion  : "*"? // Make sure the token does not get lost.
-qgate       : "QGate[" string "]" inversion "(" wire ")" control_app
+qgate       : "QGate[" string "]" inversion "(" wire_list ")" control_app
 qrot        : "QRot[" string "," float "]" inversion "(" wire ")"
 gphase      : "Gphase() with t=" float control_app "with anchors=[" wire_list "]"
 cnot        : "CNot(" wire ")" control_app

--- a/quippy/transformer.py
+++ b/quippy/transformer.py
@@ -75,10 +75,12 @@ class QuipperTransformer(Transformer):
             op = ops.Omega
         elif n == "iX":
             op = ops.IX
+        elif n == "W":
+            op = ops.W
         else:
             raise RuntimeError("Unknown QGate operation: {}".format(n))
 
-        return QGate(op=op, inverted=len(t[1].children) > 0, wire=t[2], control=t[3])
+        return QGate(op=op, inverted=len(t[1].children) > 0, wires=t[2], control=t[3])
 
     def qrot(self, t):
         ops = QRot_Op
@@ -225,7 +227,7 @@ class QGate_Op(Enum):
 class QGate(Gate, NamedTuple('QGate', [
     ('op', QGate_Op),
     ('inverted', bool),
-    ('wire', Wire),
+    ('wires', List[Wire]),
     ('control', Control)
     ])):
     pass

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -78,7 +78,7 @@ class TestParser(TestCase):
         self.assertEqual(Tree('qgate', [
             Tree('string', ['"not"']),
             Tree('inversion', []),
-            Tree('wire', [Tree('int', ["0"])]),
+            Tree('wire_list', [Tree('wire', [Tree('int', ['0'])])]),
             Tree('control_app', [
                 Tree('wire_list', [
                     Tree('wire', [Tree('int', ["+2"])]),
@@ -194,7 +194,7 @@ class TestParser(TestCase):
             Tree('qgate', [
                 Tree('string', ['"H"']),
                 Tree('inversion', ['*']),
-                Tree('wire', [Tree('int', ['0'])]),
+                Tree('wire_list', [Tree('wire', [Tree('int', ['0'])])]),
                 Tree('control_app', [
                     Tree('wire_list', [
                         Tree('wire', [Tree('int', ['+3'])]),
@@ -224,6 +224,82 @@ class TestParser(TestCase):
             'yes',
             circuit_tree
             ]), parsed)
+
+    def test_multi(self):
+        text = '''Inputs: 0:Qbit, 1:Qbit, 2:Qbit
+        QGate["multinot"](0,1) with controls=[+2] with nocontrol
+        QGate["swap"](0,1) with controls=[+2]
+        QGate["W"](1,2) with controls=[+0]
+        Outputs: 0:Qbit, 1:Qbit, 2:Qbit
+        '''
+        parser = self.parser()
+        parsed = parser.parse(text)
+        self.assertEqual(Tree('start', [
+            Tree('circuit', [
+                Tree('arity', [
+                    Tree('type_assignment', [
+                        Tree('wire', [
+                            Tree('int', ['0'])]),
+                        'Qbit']),
+                    Tree('type_assignment', [
+                        Tree('wire', [
+                            Tree('int', ['1'])]),
+                        'Qbit']),
+                    Tree('type_assignment', [
+                        Tree('wire', [
+                            Tree('int', ['2'])]),
+                        'Qbit'])]),
+                Tree('qgate', [
+                    Tree('string', ['"multinot"']),
+                    Tree('inversion', []),
+                    Tree('wire_list', [
+                        Tree('wire', [
+                            Tree('int', ['0'])]),
+                        Tree('wire', [
+                            Tree('int', ['1'])])]),
+                    Tree('control_app', [
+                        Tree('wire_list', [
+                            Tree('wire', [
+                                Tree('int', ['+2'])])]),
+                        'with nocontrol'])]),
+                Tree('qgate', [
+                    Tree('string', ['"swap"']),
+                    Tree('inversion', []),
+                    Tree('wire_list', [
+                        Tree('wire', [
+                            Tree('int', ['0'])]),
+                        Tree('wire', [
+                            Tree('int', ['1'])])]),
+                    Tree('control_app', [
+                        Tree('wire_list', [
+                            Tree('wire', [
+                                Tree('int', ['+2'])])])])]),
+                Tree('qgate', [
+                    Tree('string', ['"W"']),
+                    Tree('inversion', []),
+                    Tree('wire_list', [
+                        Tree('wire', [
+                            Tree('int', ['1'])]),
+                        Tree('wire', [
+                            Tree('int', ['2'])])]),
+                    Tree('control_app', [
+                        Tree('wire_list', [
+                            Tree('wire', [
+                                Tree('int', ['+0'])])])])]),
+                Tree('arity', [
+                    Tree('type_assignment', [
+                        Tree('wire', [
+                            Tree('int', ['0'])]),
+                        'Qbit']),
+                    Tree('type_assignment', [
+                        Tree('wire', [
+                            Tree('int', ['1'])]),
+                        'Qbit']),
+                    Tree('type_assignment', [
+                        Tree('wire', [
+                            Tree('int', ['2'])]),
+                        'Qbit'])])])]),
+        parsed)
 
     @unittest.skip
     def test_optimizer(self):

--- a/test/test_transformer.py
+++ b/test/test_transformer.py
@@ -57,7 +57,7 @@ class TestTransformer(TestCase):
         self.assertEqual(QGate(
             op=QGate_Op.Not,
             inverted=False,
-            wire=Wire(0),
+            wires=[Wire(0)],
             control=Control(controlled=[Wire(2), Wire(-3)], no_control=True)
             ), parsed)
 
@@ -164,7 +164,7 @@ class TestTransformer(TestCase):
                 QGate(
                     op=QGate_Op.H,
                     inverted=True,
-                    wire=Wire(0),
+                    wires=[Wire(0)],
                     control=Control(
                         controlled=[
                             Wire(3),
@@ -206,7 +206,7 @@ class TestTransformer(TestCase):
                     QGate(
                         op=QGate_Op.H,
                         inverted=True,
-                        wire=Wire(0),
+                        wires=[Wire(0)],
                         control=Control(
                             controlled=[
                                 Wire(3),
@@ -227,6 +227,50 @@ class TestTransformer(TestCase):
                 ),
             subroutines=[]
             )
+        self.assertEqual(expected_start, parsed)
+
+    def test_multi(self):
+        text = '''Inputs: 0:Qbit, 1:Qbit, 2:Qbit
+        QGate["multinot"](0,1) with controls=[+2] with nocontrol
+        QGate["swap"](0,1) with controls=[+2]
+        QGate["W"](1,2) with controls=[+0]
+        Outputs: 0:Qbit, 1:Qbit, 2:Qbit
+        '''
+        parser = self.parser()
+        parsed = parser.parse(text)
+        expected_start = Start(
+            circuit=Circuit(
+                inputs=[
+                    TypeAssignment(Wire(0), TypeAssignment_Type.Qbit),
+                    TypeAssignment(Wire(1), TypeAssignment_Type.Qbit),
+                    TypeAssignment(Wire(2), TypeAssignment_Type.Qbit)],
+                gates=[
+                    QGate(
+                        op=QGate_Op.MultiNot,
+                        inverted=False,
+                        wires=[Wire(0), Wire(1)],
+                        control=Control(
+                            controlled=[Wire(2)],
+                            no_control=True)),
+                    QGate(
+                        op=QGate_Op.Swap,
+                        inverted=False,
+                        wires=[Wire(0), Wire(1)],
+                        control=Control(
+                            controlled=[Wire(2)],
+                            no_control=False)),
+                    QGate(
+                        op=QGate_Op.W,
+                        inverted=False,
+                        wires=[Wire(1), Wire(2)],
+                        control=Control(
+                            controlled=[Wire(0)],
+                            no_control=False))],
+                outputs=[
+                    TypeAssignment(Wire(0), TypeAssignment_Type.Qbit),
+                    TypeAssignment(Wire(1), TypeAssignment_Type.Qbit),
+                    TypeAssignment(Wire(2), TypeAssignment_Type.Qbit)]),
+            subroutines=[])
         self.assertEqual(expected_start, parsed)
 
     def test_optimizer_pf6_30_before(self):


### PR DESCRIPTION
Make `QGate` expect a `wire_list` rather than a `wire`.
Add missing `W` support to the transformer.
Add tests for `multinot`, `swap` and `W` gates.
Fixes https://github.com/eddieschoute/quippy/issues/1